### PR TITLE
Add query parameters supported by CC 3.165.0 list operations

### DIFF
--- a/client/app.go
+++ b/client/app.go
@@ -20,11 +20,11 @@ type AppListOptions struct {
 	SpaceGUIDs        Filter                 `qs:"space_guids"`
 	Stacks            Filter                 `qs:"stacks"`
 	LifecycleType     resource.LifecycleType `qs:"lifecycle_type"`
+	LabelSel          LabelSelector          `qs:"label_selector"`
+	CreatedAts        TimestampFilter        `qs:"created_ats"`
+	UpdatedAts        TimestampFilter        `qs:"updated_ats"`
 
-	Include    resource.AppIncludeType `qs:"include"`
-	LabelSel   LabelSelector           `qs:"label_selector"`
-	CreatedAts TimestampFilter         `qs:"created_ats"`
-	UpdatedAts TimestampFilter         `qs:"updated_ats"`
+	Include resource.AppIncludeType `qs:"include"`
 }
 
 // NewAppListOptions creates new options to pass to list

--- a/client/app.go
+++ b/client/app.go
@@ -14,14 +14,17 @@ type AppClient commonClient
 type AppListOptions struct {
 	*ListOptions
 
-	GUIDs             Filter `qs:"guids"`
-	Names             Filter `qs:"names"`
-	OrganizationGUIDs Filter `qs:"organization_guids"`
-	SpaceGUIDs        Filter `qs:"space_guids"`
-	Stacks            Filter `qs:"stacks"`
+	GUIDs             Filter                 `qs:"guids"`
+	Names             Filter                 `qs:"names"`
+	OrganizationGUIDs Filter                 `qs:"organization_guids"`
+	SpaceGUIDs        Filter                 `qs:"space_guids"`
+	Stacks            Filter                 `qs:"stacks"`
+	LifecycleType     resource.LifecycleType `qs:"lifecycle_type"`
 
-	LifecycleType resource.LifecycleType  `qs:"lifecycle_type"`
-	Include       resource.AppIncludeType `qs:"include"`
+	Include    resource.AppIncludeType `qs:"include"`
+	LabelSel   LabelSelector           `qs:"label_selector"`
+	CreatedAts TimestampFilter         `qs:"created_ats"`
+	UpdatedAts TimestampFilter         `qs:"updated_ats"`
 }
 
 // NewAppListOptions creates new options to pass to list

--- a/client/app_usage.go
+++ b/client/app_usage.go
@@ -13,6 +13,10 @@ type AppUsageClient commonClient
 // AppUsageListOptions list filters
 type AppUsageListOptions struct {
 	*ListOptions
+
+	AfterGUID  string          `qs:"after_guid"`
+	GUIDs      Filter          `qs:"guids"`
+	CreatedAts TimestampFilter `qs:"created_ats"`
 }
 
 // NewAppUsageOptions creates new options to pass to list

--- a/client/audit_event.go
+++ b/client/audit_event.go
@@ -18,6 +18,8 @@ type AuditEventListOptions struct {
 	TargetGUIDs       ExclusionFilter `qs:"target_guids"` // list of target guids to filter by
 	OrganizationGUIDs Filter          `qs:"organization_guids"`
 	SpaceGUIDs        Filter          `qs:"space_guids"`
+	CreatedAts        TimestampFilter `qs:"created_ats"`
+	UpdatedAts        TimestampFilter `qs:"updated_ats"`
 }
 
 // NewAuditEventListOptions creates new options to pass to list

--- a/client/buildpack.go
+++ b/client/buildpack.go
@@ -15,8 +15,11 @@ type BuildpackClient commonClient
 type BuildpackListOptions struct {
 	*ListOptions
 
-	Names  Filter `qs:"names"`  // list of buildpack names to filter by
-	Stacks Filter `qs:"stacks"` // list of stack names to filter by
+	Names      Filter          `qs:"names"`  // list of buildpack names to filter by
+	Stacks     Filter          `qs:"stacks"` // list of stack names to filter by
+	LabelSel   LabelSelector   `qs:"label_selector"`
+	CreatedAts TimestampFilter `qs:"created_ats"`
+	UpdatedAts TimestampFilter `qs:"updated_ats"`
 }
 
 // NewBuildpackListOptions creates new options to pass to list

--- a/client/deployment.go
+++ b/client/deployment.go
@@ -15,10 +15,13 @@ type DeploymentClient commonClient
 type DeploymentListOptions struct {
 	*ListOptions
 
-	AppGUIDs      Filter `qs:"app_guids"`
-	States        Filter `qs:"states"`
-	StatusReasons Filter `qs:"status_reasons"`
-	StatusValues  Filter `qs:"status_values"`
+	AppGUIDs      Filter          `qs:"app_guids"`
+	States        Filter          `qs:"states"`
+	StatusReasons Filter          `qs:"status_reasons"`
+	StatusValues  Filter          `qs:"status_values"`
+	LabelSel      LabelSelector   `qs:"label_selector"`
+	CreatedAts    TimestampFilter `qs:"created_ats"`
+	UpdatedAts    TimestampFilter `qs:"updated_ats"`
 }
 
 // NewDeploymentListOptions creates new options to pass to list

--- a/client/domain.go
+++ b/client/domain.go
@@ -14,9 +14,12 @@ type DomainClient commonClient
 type DomainListOptions struct {
 	*ListOptions
 
-	GUIDs             Filter `qs:"guids"`
-	Names             Filter `qs:"names"`
-	OrganizationGUIDs Filter `qs:"organization_guids"`
+	GUIDs             Filter          `qs:"guids"`
+	Names             Filter          `qs:"names"`
+	OrganizationGUIDs Filter          `qs:"organization_guids"`
+	LabelSel          LabelSelector   `qs:"label_selector"`
+	CreatedAts        TimestampFilter `qs:"created_ats"`
+	UpdatedAts        TimestampFilter `qs:"updated_ats"`
 }
 
 // NewDomainListOptions creates new options to pass to list

--- a/client/droplet.go
+++ b/client/droplet.go
@@ -15,11 +15,14 @@ type DropletClient commonClient
 type DropletListOptions struct {
 	*ListOptions
 
-	GUIDs             Filter `qs:"guids"`              // list of droplet guids to filter by
-	States            Filter `qs:"states"`             // list of droplet states to filter by
-	AppGUIDs          Filter `qs:"app_guids"`          // list of app guids to filter by
-	SpaceGUIDs        Filter `qs:"space_guids"`        // list of space guids to filter by
-	OrganizationGUIDs Filter `qs:"organization_guids"` // list of organization guids to filter by
+	GUIDs             Filter          `qs:"guids"`              // list of droplet guids to filter by
+	States            Filter          `qs:"states"`             // list of droplet states to filter by
+	AppGUIDs          Filter          `qs:"app_guids"`          // list of app guids to filter by
+	SpaceGUIDs        Filter          `qs:"space_guids"`        // list of space guids to filter by
+	OrganizationGUIDs Filter          `qs:"organization_guids"` // list of organization guids to filter by
+	LabelSel          LabelSelector   `qs:"label_selector"`
+	CreatedAts        TimestampFilter `qs:"created_ats"`
+	UpdatedAts        TimestampFilter `qs:"updated_ats"`
 }
 
 // NewDropletListOptions creates new options to pass to list

--- a/client/feature_flag.go
+++ b/client/feature_flag.go
@@ -13,6 +13,7 @@ type FeatureFlagClient commonClient
 // FeatureFlagListOptions list filters
 type FeatureFlagListOptions struct {
 	*ListOptions
+	UpdatedAts TimestampFilter `qs:"updated_ats"`
 }
 
 // NewFeatureFlagListOptions creates new options to pass to list

--- a/client/isolation_segment.go
+++ b/client/isolation_segment.go
@@ -14,9 +14,12 @@ type IsolationSegmentClient commonClient
 type IsolationSegmentListOptions struct {
 	*ListOptions
 
-	GUIDs             Filter `qs:"guids"`
-	Names             Filter `qs:"names"`
-	OrganizationGUIDs Filter `qs:"organization_guids"`
+	GUIDs             Filter          `qs:"guids"`
+	Names             Filter          `qs:"names"`
+	OrganizationGUIDs Filter          `qs:"organization_guids"`
+	LabelSel          LabelSelector   `qs:"label_selector"`
+	CreatedAts        TimestampFilter `qs:"created_ats"`
+	UpdatedAts        TimestampFilter `qs:"updated_ats"`
 }
 
 // NewIsolationSegmentOptions creates new options to pass to list

--- a/client/organization.go
+++ b/client/organization.go
@@ -13,8 +13,11 @@ type OrganizationClient commonClient
 type OrganizationListOptions struct {
 	*ListOptions
 
-	GUIDs Filter `qs:"guids"` // list of organization guids to filter by
-	Names Filter `qs:"names"` // list of organization names to filter by
+	GUIDs      Filter          `qs:"guids"` // list of organization guids to filter by
+	Names      Filter          `qs:"names"` // list of organization names to filter by
+	LabelSel   LabelSelector   `qs:"label_selector"`
+	CreatedAts TimestampFilter `qs:"created_ats"`
+	UpdatedAts TimestampFilter `qs:"updated_ats"`
 }
 
 // NewOrganizationListOptions creates new options to pass to list

--- a/client/organization_quota.go
+++ b/client/organization_quota.go
@@ -14,9 +14,11 @@ type OrganizationQuotaClient commonClient
 type OrganizationQuotaListOptions struct {
 	*ListOptions
 
-	GUIDs             Filter `qs:"guids"`
-	Names             Filter `qs:"names"`
-	OrganizationGUIDs Filter `qs:"organization_guids"`
+	GUIDs             Filter          `qs:"guids"`
+	Names             Filter          `qs:"names"`
+	OrganizationGUIDs Filter          `qs:"organization_guids"`
+	CreatedAts        TimestampFilter `qs:"created_ats"`
+	UpdatedAts        TimestampFilter `qs:"updated_ats"`
 }
 
 // NewOrganizationQuotaListOptions creates new options to pass to list

--- a/client/package.go
+++ b/client/package.go
@@ -15,9 +15,15 @@ type PackageClient commonClient
 type PackageListOptions struct {
 	*ListOptions
 
-	GUIDs  Filter `qs:"guids"`  // list of package guids to filter by
-	States Filter `qs:"states"` // list of package states to filter by
-	Types  Filter `qs:"types"`  // list of package types to filter by, docker or bits
+	GUIDs             Filter          `qs:"guids"`              // list of package guids to filter by
+	States            Filter          `qs:"states"`             // list of package states to filter by
+	Types             Filter          `qs:"types"`              // list of package types to filter by, docker or bits
+	AppGUIDs          Filter          `qs:"app_guids"`          // list of app guids to filter by
+	SpaceGUIDs        Filter          `qs:"space_guids"`        // list of space guids to filter by
+	OrganizationGUIDs Filter          `qs:"organization_guids"` // list of organization guids to filter by
+	LabelSel          LabelSelector   `qs:"label_selector"`
+	CreatedAts        TimestampFilter `qs:"created_ats"`
+	UpdatedAts        TimestampFilter `qs:"updated_ats"`
 }
 
 // NewPackageListOptions creates new options to pass to list

--- a/client/process.go
+++ b/client/process.go
@@ -14,12 +14,14 @@ type ProcessClient commonClient
 type ProcessListOptions struct {
 	*ListOptions
 
-	GUIDs             Filter `qs:"guids"`
-	Types             Filter `qs:"types"`
-	Names             Filter `qs:"names"`
-	AppGUIDs          Filter `qs:"app_guids"`
-	SpaceGUIDs        Filter `qs:"space_guids"`
-	OrganizationGUIDs Filter `qs:"organization_guids"`
+	GUIDs             Filter          `qs:"guids"`
+	Types             Filter          `qs:"types"`
+	AppGUIDs          Filter          `qs:"app_guids"`
+	SpaceGUIDs        Filter          `qs:"space_guids"`
+	OrganizationGUIDs Filter          `qs:"organization_guids"`
+	LabelSel          LabelSelector   `qs:"label_selector"`
+	CreatedAts        TimestampFilter `qs:"created_ats"`
+	UpdatedAts        TimestampFilter `qs:"updated_ats"`
 }
 
 // NewProcessOptions creates new options to pass to list

--- a/client/revision.go
+++ b/client/revision.go
@@ -14,7 +14,10 @@ type RevisionClient commonClient
 type RevisionListOptions struct {
 	*ListOptions
 
-	Versions Filter `qs:"versions"`
+	Versions   Filter          `qs:"versions"`
+	LabelSel   LabelSelector   `qs:"label_selector"`
+	CreatedAts TimestampFilter `qs:"created_ats"`
+	UpdatedAts TimestampFilter `qs:"updated_ats"`
 }
 
 // NewRevisionListOptions creates new options to pass to list

--- a/client/role.go
+++ b/client/role.go
@@ -14,11 +14,13 @@ type RoleClient commonClient
 type RoleListOptions struct {
 	*ListOptions
 
-	GUIDs             Filter `qs:"guids"`              // list of role guids to filter by
-	Types             Filter `qs:"types"`              // list of role types to filter by
-	OrganizationGUIDs Filter `qs:"organization_guids"` // list of organization guids to filter by
-	SpaceGUIDs        Filter `qs:"space_guids"`        // list of space guids to filter by
-	UserGUIDs         Filter `qs:"user_guids"`         // list of user guids to filter by
+	GUIDs             Filter          `qs:"guids"`              // list of role guids to filter by
+	Types             Filter          `qs:"types"`              // list of role types to filter by
+	OrganizationGUIDs Filter          `qs:"organization_guids"` // list of organization guids to filter by
+	SpaceGUIDs        Filter          `qs:"space_guids"`        // list of space guids to filter by
+	UserGUIDs         Filter          `qs:"user_guids"`         // list of user guids to filter by
+	CreatedAts        TimestampFilter `qs:"created_ats"`
+	UpdatedAts        TimestampFilter `qs:"updated_ats"`
 
 	Include resource.RoleIncludeType `qs:"include"`
 }

--- a/client/route.go
+++ b/client/route.go
@@ -20,9 +20,12 @@ type RouteListOptions struct {
 	OrganizationGUIDs    Filter `qs:"organization_guids"`
 	ServiceInstanceGUIDs Filter `qs:"service_instance_guids"`
 
-	Hosts Filter `qs:"hosts"`
-	Paths Filter `qs:"paths"`
-	Ports Filter `qs:"ports"`
+	Hosts      Filter          `qs:"hosts"`
+	Paths      Filter          `qs:"paths"`
+	Ports      Filter          `qs:"ports"`
+	LabelSel   LabelSelector   `qs:"label_selector"`
+	CreatedAts TimestampFilter `qs:"created_ats"`
+	UpdatedAts TimestampFilter `qs:"updated_ats"`
 
 	Include resource.RouteIncludeType `qs:"include"`
 }

--- a/client/security_group.go
+++ b/client/security_group.go
@@ -21,6 +21,9 @@ type SecurityGroupListOptions struct {
 
 	GloballyEnabledRunning *bool `qs:"globally_enabled_running"` // If true, only include the security groups that are enabled for running
 	GloballyEnabledStaging *bool `qs:"globally_enabled_staging"` // If true, only include the security groups that are enabled for staging
+
+	CreatedAts TimestampFilter `qs:"created_ats"`
+	UpdatedAts TimestampFilter `qs:"updated_ats"`
 }
 
 // NewSecurityGroupListOptions creates new options to pass to list

--- a/client/service_broker.go
+++ b/client/service_broker.go
@@ -14,8 +14,11 @@ type ServiceBrokerClient commonClient
 type ServiceBrokerListOptions struct {
 	*ListOptions
 
-	SpaceGUIDs Filter `qs:"space_guids"`
-	Names      Filter `qs:"names"`
+	SpaceGUIDs Filter          `qs:"space_guids"`
+	Names      Filter          `qs:"names"`
+	LabelSel   LabelSelector   `qs:"label_selector"`
+	CreatedAts TimestampFilter `qs:"created_ats"`
+	UpdatedAts TimestampFilter `qs:"updated_ats"`
 }
 
 // NewServiceBrokerListOptions creates new options to pass to list

--- a/client/service_credential_binding.go
+++ b/client/service_credential_binding.go
@@ -26,7 +26,10 @@ type ServiceCredentialBindingListOptions struct {
 	Type                 Filter `qs:"type"`                   // list of service credential binding types to filter by, app or key
 	GUIDs                Filter `qs:"guids"`                  // list of service route binding guids to filter by
 
-	Include resource.ServiceCredentialBindingIncludeType `qs:"include"`
+	LabelSel   LabelSelector                                `qs:"label_selector"`
+	CreatedAts TimestampFilter                              `qs:"created_ats"`
+	UpdatedAts TimestampFilter                              `qs:"updated_ats"`
+	Include    resource.ServiceCredentialBindingIncludeType `qs:"include"`
 }
 
 // NewServiceCredentialBindingListOptions creates new options to pass to list

--- a/client/service_instance.go
+++ b/client/service_instance.go
@@ -22,6 +22,10 @@ type ServiceInstanceListOptions struct {
 	OrganizationGUIDs Filter `qs:"organization_guids"`
 	ServicePlanGUIDs  Filter `qs:"service_plan_guids"`
 	ServicePlanNames  Filter `qs:"service_plan_names"`
+
+	LabelSel   LabelSelector   `qs:"label_selector"`
+	CreatedAts TimestampFilter `qs:"created_ats"`
+	UpdatedAts TimestampFilter `qs:"updated_ats"`
 }
 
 // NewServiceInstanceListOptions creates new options to pass to list

--- a/client/service_offering.go
+++ b/client/service_offering.go
@@ -14,12 +14,15 @@ type ServiceOfferingClient commonClient
 type ServiceOfferingListOptions struct {
 	*ListOptions
 
-	Names              Filter `qs:"names"`
-	ServiceBrokerGUIDs Filter `qs:"service_broker_guids"`
-	ServiceBrokerNames Filter `qs:"service_broker_names"`
-	SpaceGUIDs         Filter `qs:"space_guids"`
-	OrganizationGUIDs  Filter `qs:"organization_guids"`
-	Available          *bool  `qs:"available"`
+	Names              Filter          `qs:"names"`
+	ServiceBrokerGUIDs Filter          `qs:"service_broker_guids"`
+	ServiceBrokerNames Filter          `qs:"service_broker_names"`
+	SpaceGUIDs         Filter          `qs:"space_guids"`
+	OrganizationGUIDs  Filter          `qs:"organization_guids"`
+	Available          *bool           `qs:"available"`
+	LabelSel           LabelSelector   `qs:"label_selector"`
+	CreatedAts         TimestampFilter `qs:"created_ats"`
+	UpdatedAts         TimestampFilter `qs:"updated_ats"`
 }
 
 // NewServiceOfferingListOptions creates new options to pass to list

--- a/client/service_plan.go
+++ b/client/service_plan.go
@@ -15,16 +15,18 @@ type ServicePlanClient commonClient
 type ServicePlanListOptions struct {
 	*ListOptions
 
-	Names                Filter `qs:"names"`
-	BrokerCatalogIDs     Filter `qs:"broker_catalog_ids"`
-	SpaceGUIDs           Filter `qs:"space_guids"`
-	OrganizationGUIDs    Filter `qs:"organization_guids"`
-	ServiceBrokerGUIDs   Filter `qs:"service_broker_guids"`
-	ServiceBrokerNames   Filter `qs:"service_broker_names"`
-	ServiceOfferingGUIDs Filter `qs:"service_offering_guids"`
-	ServiceOfferingNames Filter `qs:"service_offering_names"`
-	ServiceInstanceGUIDs Filter `qs:"service_instance_guids"`
-	Available            *bool  `qs:"available"`
+	Names                Filter          `qs:"names"`
+	BrokerCatalogIDs     Filter          `qs:"broker_catalog_ids"`
+	SpaceGUIDs           Filter          `qs:"space_guids"`
+	OrganizationGUIDs    Filter          `qs:"organization_guids"`
+	ServiceBrokerGUIDs   Filter          `qs:"service_broker_guids"`
+	ServiceBrokerNames   Filter          `qs:"service_broker_names"`
+	ServiceOfferingGUIDs Filter          `qs:"service_offering_guids"`
+	ServiceOfferingNames Filter          `qs:"service_offering_names"`
+	ServiceInstanceGUIDs Filter          `qs:"service_instance_guids"`
+	LabelSel             LabelSelector   `qs:"label_selector"`
+	CreatedAts           TimestampFilter `qs:"created_ats"`
+	UpdatedAts           TimestampFilter `qs:"updated_ats"`
 
 	Include resource.ServicePlanIncludeType `qs:"include"`
 }

--- a/client/service_route_binding.go
+++ b/client/service_route_binding.go
@@ -14,10 +14,13 @@ type ServiceRouteBindingClient commonClient
 type ServiceRouteBindingListOptions struct {
 	*ListOptions
 
-	GUIDs                Filter `qs:"guids"`
-	RouteGUIDs           Filter `qs:"route_guids"`
-	ServiceInstanceGUIDs Filter `qs:"service_instance_guids"`
-	ServiceInstanceNames Filter `qs:"service_instance_names"`
+	GUIDs                Filter          `qs:"guids"`
+	RouteGUIDs           Filter          `qs:"route_guids"`
+	ServiceInstanceGUIDs Filter          `qs:"service_instance_guids"`
+	ServiceInstanceNames Filter          `qs:"service_instance_names"`
+	LabelSel             LabelSelector   `qs:"label_selector"`
+	CreatedAts           TimestampFilter `qs:"created_ats"`
+	UpdatedAts           TimestampFilter `qs:"updated_ats"`
 
 	Include resource.ServiceRouteBindingIncludeType `qs:"include"`
 }

--- a/client/service_usage.go
+++ b/client/service_usage.go
@@ -14,10 +14,12 @@ type ServiceUsageClient commonClient
 type ServiceUsageListOptions struct {
 	*ListOptions
 
-	AfterGUID            string `qs:"after_guid"`
-	GUIDs                Filter `qs:"guids"`
-	ServiceInstanceTypes Filter `qs:"service_instance_types"`
-	ServiceOfferingGUIDs Filter `qs:"service_offering_guids"`
+	AfterGUID            string          `qs:"after_guid"`
+	GUIDs                Filter          `qs:"guids"`
+	ServiceInstanceTypes Filter          `qs:"service_instance_types"`
+	ServiceOfferingGUIDs Filter          `qs:"service_offering_guids"`
+	CreatedAts           TimestampFilter `qs:"created_ats"`
+	UpdatedAts           TimestampFilter `qs:"updated_ats"`
 }
 
 // NewServiceUsageOptions creates new options to pass to list

--- a/client/sidecar.go
+++ b/client/sidecar.go
@@ -13,6 +13,8 @@ type SidecarClient commonClient
 // SidecarListOptions list filters
 type SidecarListOptions struct {
 	*ListOptions
+	CreatedAts TimestampFilter `qs:"created_ats"`
+	UpdatedAts TimestampFilter `qs:"updated_ats"`
 }
 
 // NewSidecarListOptions creates new options to pass to list

--- a/client/space.go
+++ b/client/space.go
@@ -14,9 +14,12 @@ type SpaceClient commonClient
 type SpaceListOptions struct {
 	*ListOptions
 
-	GUIDs             Filter `qs:"guids"`              // list of space guids to filter by
-	Names             Filter `qs:"names"`              // list of space names to filter by
-	OrganizationGUIDs Filter `qs:"organization_guids"` // list of organization guids to filter by
+	GUIDs             Filter          `qs:"guids"`              // list of space guids to filter by
+	Names             Filter          `qs:"names"`              // list of space names to filter by
+	OrganizationGUIDs Filter          `qs:"organization_guids"` // list of organization guids to filter by
+	LabelSel          LabelSelector   `qs:"label_selector"`
+	CreatedAts        TimestampFilter `qs:"created_ats"`
+	UpdatedAts        TimestampFilter `qs:"updated_ats"`
 
 	Include resource.SpaceIncludeType `qs:"include"` // include parent objects if any
 }

--- a/client/space_quota.go
+++ b/client/space_quota.go
@@ -14,10 +14,12 @@ type SpaceQuotaClient commonClient
 type SpaceQuotaListOptions struct {
 	*ListOptions
 
-	GUIDs             Filter `qs:"guids"`
-	Names             Filter `qs:"names"`
-	OrganizationGUIDs Filter `qs:"organization_guids"`
-	SpaceGUIDs        Filter `qs:"space_guids"`
+	GUIDs             Filter          `qs:"guids"`
+	Names             Filter          `qs:"names"`
+	OrganizationGUIDs Filter          `qs:"organization_guids"`
+	SpaceGUIDs        Filter          `qs:"space_guids"`
+	CreatedAts        TimestampFilter `qs:"created_ats"`
+	UpdatedAts        TimestampFilter `qs:"updated_ats"`
 }
 
 // NewSpaceQuotaListOptions creates new options to pass to list

--- a/client/stack.go
+++ b/client/stack.go
@@ -14,7 +14,11 @@ type StackClient commonClient
 type StackListOptions struct {
 	*ListOptions
 
-	Names Filter `qs:"names"` // list of stack names to filter by
+	Names      Filter          `qs:"names"` // list of stack names to filter by
+	Default    *bool           `qs:"default"`
+	LabelSel   LabelSelector   `qs:"label_selector"`
+	CreatedAts TimestampFilter `qs:"created_ats"`
+	UpdatedAts TimestampFilter `qs:"updated_ats"`
 }
 
 // NewStackListOptions creates new options to pass to list

--- a/client/task.go
+++ b/client/task.go
@@ -14,11 +14,15 @@ type TaskClient commonClient
 type TaskListOptions struct {
 	*ListOptions
 
-	GUIDs             Filter `qs:"guids"`
-	Names             Filter `qs:"names"`
-	States            Filter `qs:"states"`
-	SpaceGUIDs        Filter `qs:"space_guids"`
-	OrganizationGUIDs Filter `qs:"organization_guids"`
+	GUIDs             Filter          `qs:"guids"`
+	Names             Filter          `qs:"names"`
+	States            Filter          `qs:"states"`
+	AppGUIDs          Filter          `qs:"app_guids"`
+	SpaceGUIDs        Filter          `qs:"space_guids"`
+	OrganizationGUIDs Filter          `qs:"organization_guids"`
+	LabelSel          LabelSelector   `qs:"label_selector"`
+	CreatedAts        TimestampFilter `qs:"created_ats"`
+	UpdatedAts        TimestampFilter `qs:"updated_ats"`
 }
 
 // NewTaskListOptions creates new options to pass to list

--- a/client/user.go
+++ b/client/user.go
@@ -28,6 +28,10 @@ type UserListOptions struct {
 	// UAA have the origin “uaa”; users authenticated by an LDAP provider have the
 	// origin ldap when filtering by origins, usernames must be included
 	Origins Filter `qs:"origins"`
+
+	LabelSel   LabelSelector   `qs:"label_selector"`
+	CreatedAts TimestampFilter `qs:"created_ats"`
+	UpdatedAts TimestampFilter `qs:"updated_ats"`
 }
 
 // NewUserListOptions creates new options to pass to list


### PR DESCRIPTION
Listing resources supports query parameters named in docs.

* `AppUsageClient` will be able to [list events](http://v3-apidocs.cloudfoundry.org/version/3.165.0/index.html#list-apps) `after_guid`
* Many clients gain support for `label_selector`, `created_at` and `updated_at`