### PR TITLE
fix: Make buildpack filename customisable

### DIFF
--- a/client/buildpack.go
+++ b/client/buildpack.go
@@ -116,10 +116,10 @@ func (c *BuildpackClient) Update(ctx context.Context, guid string, r *resource.B
 }
 
 // Upload a gzip compressed (zip) file containing a Cloud Foundry compatible buildpack
-func (c *BuildpackClient) Upload(ctx context.Context, guid string, zipFile io.Reader) (string, *resource.Buildpack, error) {
+func (c *BuildpackClient) Upload(ctx context.Context, guid string, fileName string, zipFile io.Reader) (string, *resource.Buildpack, error) {
 	p := path.Format("/v3/buildpacks/%s/upload", guid)
 	var b resource.Buildpack
-	jobGUID, err := c.client.postFileUpload(ctx, p, "bits", "buildpack.zip", zipFile, &b)
+	jobGUID, err := c.client.postFileUpload(ctx, p, "bits", fileName, zipFile, &b)
 	if err != nil {
 		return "", nil, err
 	}

--- a/client/buildpack_test.go
+++ b/client/buildpack_test.go
@@ -106,7 +106,7 @@ func TestBuildpacks(t *testing.T) {
 			Expected2: buildpack,
 			Action2: func(c *Client, t *testing.T) (any, any, error) {
 				zipFile := strings.NewReader("bp")
-				return c.Buildpacks.Upload(context.Background(), "6f3c68d0-e119-4ca2-8ce4-83661ad6e0eb", zipFile)
+				return c.Buildpacks.Upload(context.Background(), "6f3c68d0-e119-4ca2-8ce4-83661ad6e0eb", "buildpack.zip", zipFile)
 			},
 		},
 	}


### PR DESCRIPTION
fix #419 