### PR TITLE
Support parsing of environment variables other than strings.

### DIFF
--- a/client/app_test.go
+++ b/client/app_test.go
@@ -2,13 +2,12 @@ package client
 
 import (
 	"context"
+	"github.com/cloudfoundry/go-cfclient/v3/resource"
+	"github.com/stretchr/testify/require"
 	"net/http"
 	"testing"
 
-	"github.com/cloudfoundry/go-cfclient/v3/resource"
 	"github.com/cloudfoundry/go-cfclient/v3/testutil"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestApps(t *testing.T) {
@@ -20,11 +19,11 @@ func TestApps(t *testing.T) {
 	space1 := g.Space().JSON
 	space2 := g.Space().JSON
 	org := g.Organization().JSON
-	appEnvironment := g.AppEnvironment().JSON
+	appEnvironment := g.AppEnvironment()
+	appEnvironmentExpected := g.AppEnvironmentExpected(appEnvironment.Name).JSON
 	appEnvVar := g.AppEnvVar().JSON
 	appSSH := g.AppSSH().JSON
 	appPermission := g.AppPermission().JSON
-
 	tests := []RouteTest{
 		{
 			Description: "Create app",
@@ -104,10 +103,10 @@ func TestApps(t *testing.T) {
 			Route: testutil.MockRoute{
 				Method:   "GET",
 				Endpoint: "/v3/apps/1cb006ee-fb05-47e1-b541-c34179ddc446/env",
-				Output:   g.Single(appEnvironment),
+				Output:   g.Single(appEnvironment.JSON),
 				Status:   http.StatusOK,
 			},
-			Expected: appEnvironment,
+			Expected: appEnvironmentExpected,
 			Action: func(c *Client, t *testing.T) (any, error) {
 				return c.Applications.GetEnvironment(context.Background(), "1cb006ee-fb05-47e1-b541-c34179ddc446")
 			},
@@ -140,7 +139,7 @@ func TestApps(t *testing.T) {
 				Output:   g.Single(appEnvVar),
 				Status:   http.StatusOK,
 			},
-			Expected: `{ "RAILS_ENV": "production" }`,
+			Expected: `{ "RAILS_ENV": "production", "SOME_BOOLEAN": "true", "SOME_FLOAT64": "10.4", "SOME_INT": "5" }`,
 			Action: func(c *Client, t *testing.T) (any, error) {
 				return c.Applications.GetEnvironmentVariables(context.Background(), "1cb006ee-fb05-47e1-b541-c34179ddc446")
 			},

--- a/client/revision_test.go
+++ b/client/revision_test.go
@@ -38,7 +38,7 @@ func TestRevisions(t *testing.T) {
 				Output:   g.Single(appEnvVar),
 				Status:   http.StatusOK,
 			},
-			Expected: `{ "RAILS_ENV": "production" }`,
+			Expected: `{ "RAILS_ENV": "production", "SOME_BOOLEAN":"true", "SOME_FLOAT64":"10.4", "SOME_INT":"5" }`,
 			Action: func(c *Client, t *testing.T) (any, error) {
 				return c.Revisions.GetEnvironmentVariables(context.Background(), "5a49a370-92cd-4091-bb62-e0914460f7b2")
 			},

--- a/testutil/object_generator.go
+++ b/testutil/object_generator.go
@@ -119,6 +119,13 @@ func (o ObjectJSONGenerator) AppEnvironment() *JSONResource {
 	return o.renderTemplate(r, "app_environment.json")
 }
 
+func (o ObjectJSONGenerator) AppEnvironmentExpected(name string) *JSONResource {
+	r := &JSONResource{
+		Name: name,
+	}
+	return o.renderTemplate(r, "app_environment_expected.json")
+}
+
 func (o ObjectJSONGenerator) AppEnvVar() *JSONResource {
 	r := &JSONResource{}
 	return o.renderTemplate(r, "app_envvar.json")

--- a/testutil/template/app_environment_expected.json
+++ b/testutil/template/app_environment_expected.json
@@ -1,21 +1,21 @@
 {
   "staging_env_json": {
     "GEM_CACHE": "http://gem-cache.example.org",
-    "SOME_BOOLEAN": true,
-    "SOME_INT": 5,
-    "SOME_FLOAT64": 10.4
+    "SOME_BOOLEAN": "true",
+    "SOME_INT": "5",
+    "SOME_FLOAT64": "10.4"
   },
   "running_env_json": {
     "HTTP_PROXY": "http://proxy.example.org",
-    "SOME_BOOLEAN": true,
-    "SOME_INT": 5,
-    "SOME_FLOAT64": 10.4
+    "SOME_BOOLEAN": "true",
+    "SOME_INT": "5",
+    "SOME_FLOAT64": "10.4"
   },
   "environment_variables": {
     "RAILS_ENV": "production",
-    "SOME_BOOLEAN": true,
-    "SOME_INT": 5,
-    "SOME_FLOAT64": 10.4
+    "SOME_BOOLEAN": "true",
+    "SOME_INT": "5",
+    "SOME_FLOAT64": "10.4"
   },
   "system_env_json": {
     "VCAP_SERVICES": {

--- a/testutil/template/app_envvar.json
+++ b/testutil/template/app_envvar.json
@@ -1,6 +1,9 @@
 {
   "var": {
-    "RAILS_ENV": "production"
+    "RAILS_ENV": "production",
+    "SOME_BOOLEAN": true,
+    "SOME_INT": 5,
+    "SOME_FLOAT64": 10.4
   },
   "links": {
     "self": {
@@ -11,3 +14,4 @@
     }
   }
 }
+


### PR DESCRIPTION
Currently the go-cfclient throws an error when attempting to retrieve env vars for an app that are not of type string. 

For example, given the env vars:
```
○ → cf curl /v3/apps/a275abd1-8f53-4a63-b980-d81cee1cf133/environment_variables
{
   "var": {
      "SCS_CREDHUB_ENABLED": true,
      "JBP_CONFIG_OPEN_JDK_JRE": "{jre: {version: 17.+}}",
       ...
   },
   "links": {
      "self": {
         "href": "https://< sanitized >/v3/apps/a275abd1-8f53-4a63-b980-d81cee1cf133/environment_variables"
      },
      "app": {
         "href": "https://< sanitized >/v3/apps/a275abd1-8f53-4a63-b980-d81cee1cf133"
      }
   }
}
```
We observe the following failure:
time=2024-07-15T20:43:48.368890666Z caller=logger.go:73 level=error error="failed to get environment for app a275abd1-8f53-4a63-b980-d81cee1cf133: error decoding /v3/apps/a275abd1-8f53-4a63-b980-d81cee1cf133/env get response JSON before '': json: cannot unmarshal bool into Go struct field AppEnvironment.environment_variables of type string"


We added support for bool, float64 and int types. More could easily be added given our implementation but we weren't sure what other types could actually occur. Let us know if you have any questions or would like additional changes. 