### PR TITLE
Fix PaidServicesAllowed to type bool

### DIFF
--- a/resource/organization_quota.go
+++ b/resource/organization_quota.go
@@ -91,7 +91,7 @@ func (q *OrganizationQuotaCreateOrUpdate) WithPaidServicesAllowed(allowed bool) 
 	if q.Services == nil {
 		q.Services = &ServicesQuota{}
 	}
-	q.Services.PaidServicesAllowed = &allowed
+	q.Services.PaidServicesAllowed = allowed
 	return q
 }
 

--- a/resource/quota.go
+++ b/resource/quota.go
@@ -19,7 +19,7 @@ type AppsQuota struct {
 
 type ServicesQuota struct {
 	// Specifies if instances of paid service plans are permitted to be created.
-	PaidServicesAllowed *bool `json:"paid_services_allowed,omitempty"`
+	PaidServicesAllowed bool `json:"paid_services_allowed"`
 
 	// The maximum number of service instances permitted.
 	TotalServiceInstances *int `json:"total_service_instances"`

--- a/resource/space_quota.go
+++ b/resource/space_quota.go
@@ -112,7 +112,7 @@ func (s *SpaceQuotaCreateOrUpdate) WithPaidServicesAllowed(allowed bool) *SpaceQ
 	if s.Services == nil {
 		s.Services = &ServicesQuota{}
 	}
-	s.Services.PaidServicesAllowed = &allowed
+	s.Services.PaidServicesAllowed = allowed
 	return s
 }
 


### PR DESCRIPTION
The Cloud Controller API states that the PaidServicesAllowed field must not be null.
The field should be a boolean and not a *bool (pointer).
https://v3-apidocs.cloudfoundry.org/version/3.180.0/index.html#the-organization-quota-object

This way, the calling application can assume that it is not nil.
The other fields are designated as nullable or pointers and thus defined as unlimited.
This makes no sense for a boolean.

Other use cases also follow this pattern: pointer = nullable, otherwise value.

Therefore, I assume that this is a bug, which I fix with this PR.

Currently, the command `make all` throws lint warnings, which also happens to me in the main branch.