### PR TITLE
add ProcessStat fields cpu_entitlement and log_rate

### DIFF
--- a/resource/process.go
+++ b/resource/process.go
@@ -123,10 +123,12 @@ type ProcessRelationships struct {
 }
 
 type Usage struct {
-	Time   time.Time `json:"time"`
-	CPU    float64   `json:"cpu"`
-	Memory int       `json:"mem"`
-	Disk   int       `json:"disk"`
+	Time           time.Time `json:"time"`
+	CPU            float64   `json:"cpu"`
+	CPUEntitlement float64   `json:"cpu_entitlement"`
+	Memory         int       `json:"mem"`
+	Disk           int       `json:"disk"`
+	LogRate        int       `json:"log_rate"`
 }
 
 func NewProcessScale() *ProcessScale {


### PR DESCRIPTION
These 2 fields were added some time ago, but were not yet present in the go-cfclient library.