### PR TITLE
Fix: Provide empty context without deadline

### DIFF
--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -74,7 +74,7 @@ func (t *retryableAuthTransport) RoundTrip(req *http.Request) (*http.Response, e
 		drainBody(resp)
 
 		// Recreate the token source
-		src, tsErr := t.tokenSourceCreator.CreateOAuth2TokenSource(req.Context())
+		src, tsErr := t.tokenSourceCreator.CreateOAuth2TokenSource(context.Background())
 		if tsErr != nil {
 			return nil, fmt.Errorf("error re-authenticating with the OAuth2 token source: %w", tsErr)
 		}


### PR DESCRIPTION
The request context has set up a deadline of value DefaultRequestTimeout. The function CreateOAuth2TokenSource would store that context in the token source creator. The token source creator would later try to create a new Token(), but fail since the deadline would be reached.

The context passed to oauth2 package controls which HTTP client is used. See the oauth2.HTTPClient variable.

Therefore fix the situation by passing an empty context to oauth2 package.

Fixes #444