### PR TITLE
Fix: Provide http.Client instance without deadline to token source

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -123,7 +123,7 @@ func (c *Config) AuthURL(urlPath string) string {
 // on-demand.
 func (c *Config) CreateOAuth2TokenSource(ctx context.Context) (oauth2.TokenSource, error) {
 	// use our http.Client instance for token acquisition
-	oauthCtx := context.WithValue(ctx, oauth2.HTTPClient, c.httpClient)
+	oauthCtx := context.WithValue(context.Background(), oauth2.HTTPClient, c.httpClient)
 
 	twoLeggedAuthConfigFn := func() *clientcredentials.Config {
 		return &clientcredentials.Config{
@@ -161,8 +161,8 @@ func (c *Config) CreateOAuth2TokenSource(ctx context.Context) (oauth2.TokenSourc
 			authConfig.Endpoint.TokenURL = addLoginHintToURL(authConfig.Endpoint.TokenURL, c.origin)
 		}
 
-		// Login using user/pass
-		token, err := authConfig.PasswordCredentialsToken(oauthCtx, c.username, c.password)
+		// Login using user/pass with request context
+		token, err := authConfig.PasswordCredentialsToken(ctx, c.username, c.password)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The request context has set up a deadline of value DefaultRequestTimeout. The function CreateOAuth2TokenSource would store that context in the token source creator. The token source creator would later try to create a new Token(), but fail since the deadline would be reached.

The context passed to oauth2 package controls which HTTP client is used. See the oauth2.HTTPClient variable.

Therefore fix the situation by passing our http.Client instance only to oauth2 package.

The oauth2 Config.PasswordCredentialsToken case will use the request's context to ensure context deadline will be respected.

Fixes #444