### PR TITLE
Add corrected golangci-lint path to match installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ endif
 
 .PHONY: lint
 lint: lint-prepare ## Run the golangci linter
-	golangci-lint run
+	./bin/golangci-lint run
 
 .PHONY: update
 update: ## Update all dependencies


### PR DESCRIPTION
Assume golangci-lint is installed into the bin directory by the installer script.