### PR TITLE
Verbose error polling

### DIFF
--- a/client/build.go
+++ b/client/build.go
@@ -138,12 +138,15 @@ func (c *BuildClient) ListForAppAll(ctx context.Context, appGUID string, opts *B
 
 // PollStaged waits until the build is staged, fails, or times out
 func (c *BuildClient) PollStaged(ctx context.Context, guid string, opts *PollingOptions) error {
-	return PollForStateOrTimeout(func() (string, error) {
+	return PollForStateOrTimeout(func() (string, string, error) {
 		build, err := c.Get(ctx, guid)
 		if build != nil {
-			return string(build.State), err
+			if build.Error != nil {
+				return string(build.State), *build.Error, err
+			}
+			return string(build.State), "", err
 		}
-		return "", err
+		return "", "", err
 	}, string(resource.BuildStateStaged), opts)
 }
 

--- a/client/job.go
+++ b/client/job.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-
 	"github.com/cloudfoundry/go-cfclient/v3/internal/path"
 	"github.com/cloudfoundry/go-cfclient/v3/resource"
 )
@@ -35,13 +34,5 @@ func (c *JobClient) PollComplete(ctx context.Context, jobGUID string, opts *Poll
 		}
 		return "", "", err
 	}, string(resource.JobStateComplete), opts)
-
-	// attempt to return the underlying saved job error
-	if err == AsyncProcessFailedError {
-		job, _ := c.Get(ctx, jobGUID)
-		if job != nil && len(job.Errors) > 0 {
-			return job.Errors[0]
-		}
-	}
 	return err
 }

--- a/client/job.go
+++ b/client/job.go
@@ -25,8 +25,11 @@ func (c *JobClient) PollComplete(ctx context.Context, jobGUID string, opts *Poll
 		job, err := c.Get(ctx, jobGUID)
 		if job != nil {
 			var cfErrors string
-			for _, error := range job.Errors {
-				cfErrors = cfErrors + "\n" + error.Error()
+			for _, e := range job.Errors {
+				cfErrors += "\n" + e.Error()
+			}
+			for _, e := range job.Warnings {
+				cfErrors += "\n" + e.Detail
 			}
 			return string(job.State), cfErrors, err
 		}

--- a/client/job_test.go
+++ b/client/job_test.go
@@ -2,8 +2,10 @@ package client
 
 import (
 	"context"
+	"github.com/stretchr/testify/require"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/cloudfoundry/go-cfclient/v3/testutil"
 )
@@ -11,6 +13,13 @@ import (
 func TestJobs(t *testing.T) {
 	g := testutil.NewObjectJSONGenerator(1)
 	job := g.Job("COMPLETE").JSON
+	jobProcessing := g.Job("PROCESSING").JSON
+	jobFailed := g.JobFailed().JSON
+	pollingOpts := &PollingOptions{
+		FailedState:   "FAILED",
+		Timeout:       time.Second,
+		CheckInterval: time.Nanosecond,
+	}
 
 	tests := []RouteTest{
 		{
@@ -19,10 +28,41 @@ func TestJobs(t *testing.T) {
 				Method:   "GET",
 				Endpoint: "/v3/jobs/c33a5caf-77e0-4d6e-b587-5555d339bc9a",
 				Output:   g.Single(job),
-				Status:   http.StatusOK},
+				Status:   http.StatusOK,
+			},
 			Expected: job,
 			Action: func(c *Client, t *testing.T) (any, error) {
 				return c.Jobs.Get(context.Background(), "c33a5caf-77e0-4d6e-b587-5555d339bc9a")
+			},
+		},
+		{
+			Description: "Poll job that succeeds",
+			Route: testutil.MockRoute{
+				Method:   "GET",
+				Endpoint: "/v3/jobs/c33a5caf-77e0-4d6e-b587-5555d339bc9a",
+				Output:   []string{jobProcessing, job},
+				Statuses: []int{http.StatusOK, http.StatusOK},
+			},
+			Action: func(c *Client, t *testing.T) (any, error) {
+				err := c.Jobs.PollComplete(context.Background(), "c33a5caf-77e0-4d6e-b587-5555d339bc9a", pollingOpts)
+				return nil, err
+			},
+		},
+		{
+			Description: "Poll job that fails",
+			Route: testutil.MockRoute{
+				Method:   "GET",
+				Endpoint: "/v3/jobs/40e49716-44a3-4ae9-9926-d1a804acf70c",
+				Output:   []string{jobProcessing, jobFailed},
+				Statuses: []int{http.StatusOK, http.StatusOK},
+			},
+			Action: func(c *Client, t *testing.T) (any, error) {
+				err := c.Jobs.PollComplete(context.Background(), "40e49716-44a3-4ae9-9926-d1a804acf70c", pollingOpts)
+				require.Error(t, err)
+				require.ErrorContains(t, err, "received state FAILED while waiting for async process")
+				require.ErrorContains(t, err, "cfclient error (CF-UnprocessableEntity|10008): something went wrong")
+				require.ErrorContains(t, err, "cfclient error (UnknownError|10001): unexpected error occurred")
+				return nil, nil
 			},
 		},
 	}

--- a/client/job_test.go
+++ b/client/job_test.go
@@ -62,6 +62,7 @@ func TestJobs(t *testing.T) {
 				require.ErrorContains(t, err, "received state FAILED while waiting for async process")
 				require.ErrorContains(t, err, "cfclient error (CF-UnprocessableEntity|10008): something went wrong")
 				require.ErrorContains(t, err, "cfclient error (UnknownError|10001): unexpected error occurred")
+				require.ErrorContains(t, err, "some warning")
 				return nil, nil
 			},
 		},

--- a/client/package.go
+++ b/client/package.go
@@ -143,12 +143,12 @@ func (c *PackageClient) ListForAppAll(ctx context.Context, appGUID string, opts 
 
 // PollReady waits until the package is ready, fails, or times out
 func (c *PackageClient) PollReady(ctx context.Context, guid string, opts *PollingOptions) error {
-	return PollForStateOrTimeout(func() (string, error) {
+	return PollForStateOrTimeout(func() (string, string, error) {
 		pkg, err := c.Get(ctx, guid)
 		if pkg != nil {
-			return string(pkg.State), err
+			return string(pkg.State), "", err
 		}
-		return "", err
+		return "", "", err
 	}, string(resource.PackageStateReady), opts)
 }
 

--- a/client/polling.go
+++ b/client/polling.go
@@ -22,7 +22,7 @@ func NewPollingOptions() *PollingOptions {
 	}
 }
 
-type getStateFunc func() (string, error)
+type getStateFunc func() (string, string, error)
 
 func PollForStateOrTimeout(getState getStateFunc, successState string, opts *PollingOptions) error {
 	if opts == nil {
@@ -38,7 +38,7 @@ func PollForStateOrTimeout(getState getStateFunc, successState string, opts *Pol
 		case <-timeout:
 			return AsyncProcessTimeoutError
 		case <-ticker.C:
-			state, err := getState()
+			state, cferror, err := getState()
 			if err != nil {
 				return err
 			}
@@ -46,7 +46,7 @@ func PollForStateOrTimeout(getState getStateFunc, successState string, opts *Pol
 			case successState:
 				return nil
 			case opts.FailedState:
-				return AsyncProcessFailedError
+				return errors.Join(AsyncProcessFailedError, errors.New(cferror))
 			}
 		}
 	}

--- a/client/polling.go
+++ b/client/polling.go
@@ -2,10 +2,10 @@ package client
 
 import (
 	"errors"
+	"fmt"
 	"time"
 )
 
-var AsyncProcessFailedError = errors.New("received state FAILED while waiting for async process")
 var AsyncProcessTimeoutError = errors.New("timed out after waiting for async process")
 
 type PollingOptions struct {
@@ -38,7 +38,7 @@ func PollForStateOrTimeout(getState getStateFunc, successState string, opts *Pol
 		case <-timeout:
 			return AsyncProcessTimeoutError
 		case <-ticker.C:
-			state, cferror, err := getState()
+			state, cfError, err := getState()
 			if err != nil {
 				return err
 			}
@@ -46,7 +46,7 @@ func PollForStateOrTimeout(getState getStateFunc, successState string, opts *Pol
 			case successState:
 				return nil
 			case opts.FailedState:
-				return errors.Join(AsyncProcessFailedError, errors.New(cferror))
+				return fmt.Errorf("received state %s while waiting for async process: %s", opts.FailedState, cfError)
 			}
 		}
 	}

--- a/client/polling_test.go
+++ b/client/polling_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"errors"
 	"testing"
 	"time"
 
@@ -33,7 +32,8 @@ func TestPollForStateOrTimeout(t *testing.T) {
 	}
 
 	err := PollForStateOrTimeout(failedFn, "NOPE", noWaitOpts)
-	require.Equal(t, errors.Join(AsyncProcessFailedError, errors.New(CustomStagingErr)), err)
+	require.Error(t, err)
+	require.Equal(t, "received state FAILED while waiting for async process: "+CustomStagingErr, err.Error())
 
 	err = PollForStateOrTimeout(successFn, "SUCCESS", noWaitOpts)
 	require.NoError(t, err)

--- a/operation/push.go
+++ b/operation/push.go
@@ -187,12 +187,12 @@ func (p *AppPushOperation) waitForDeployment(ctx context.Context, deploymentGUID
 	pollOptions := client.NewPollingOptions()
 	pollOptions.Timeout = time.Duration(instances) * time.Minute
 
-	depPollErr := client.PollForStateOrTimeout(func() (string, error) {
+	depPollErr := client.PollForStateOrTimeout(func() (string, string, error) {
 		deployment, err := p.client.Deployments.Get(ctx, deploymentGUID)
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
-		return deployment.Status.Value, nil
+		return deployment.Status.Value, deployment.Status.Reason, nil
 	}, "FINALIZED", pollOptions)
 	return depPollErr
 }

--- a/testutil/object_generator.go
+++ b/testutil/object_generator.go
@@ -228,6 +228,13 @@ func (o ObjectJSONGenerator) Job(state string) *JSONResource {
 	return o.renderTemplate(r, "job.json")
 }
 
+func (o ObjectJSONGenerator) JobFailed() *JSONResource {
+	r := &JSONResource{
+		GUID: RandomGUID(),
+	}
+	return o.renderTemplate(r, "job_failed.json")
+}
+
 func (o ObjectJSONGenerator) Manifest() *JSONResource {
 	r := &JSONResource{}
 	return o.renderTemplate(r, "manifest.yml")

--- a/testutil/template/job_failed.json
+++ b/testutil/template/job_failed.json
@@ -1,0 +1,29 @@
+{
+  "guid": "{{.GUID}}",
+  "created_at": "2016-10-19T20:25:04Z",
+  "updated_at": "2016-11-08T16:41:26Z",
+  "operation": "app.create",
+  "state": "FAILED",
+  "links": {
+    "self": {
+      "href": "https://api.example.org/v3/jobs/{{.GUID}}"
+    }
+  },
+  "errors": [
+    {
+      "code": 10008,
+      "title": "CF-UnprocessableEntity",
+      "detail": "something went wrong"
+    },
+    {
+      "code": 10001,
+      "title": "UnknownError",
+      "detail": "unexpected error occurred"
+    }
+  ],
+  "warnings": [
+    {
+      "detail": "some warning"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #437 and adds to PR #438.

Error and warning details are now returned as part of the polling function. This allows consumers to know why an operation entered the FAILED state without needing to re-query the CF API.