### PR TITLE
feat: allow droplet metadata to be updated

### DIFF
--- a/client/droplet.go
+++ b/client/droplet.go
@@ -272,6 +272,16 @@ func (c *DropletClient) Update(ctx context.Context, guid string, r *resource.Dro
 	return &d, nil
 }
 
+// UpdateMetadata of an existing droplet
+func (c *DropletClient) UpdateMetadata(ctx context.Context, guid string, r *resource.DropletMetadataUpdate) (*resource.Droplet, error) {
+	var d resource.Droplet
+	_, err := c.client.patch(ctx, path.Format("/v3/droplets/%s", guid), r, &d)
+	if err != nil {
+		return nil, err
+	}
+	return &d, nil
+}
+
 // Upload a gzip compressed tarball (tgz) file containing a Cloud Foundry compatible droplet
 func (c *DropletClient) Upload(ctx context.Context, guid string, tgzDroplet io.Reader) (string, *resource.Droplet, error) {
 	p := path.Format("/v3/droplets/%s/upload", guid)

--- a/client/droplet_test.go
+++ b/client/droplet_test.go
@@ -190,6 +190,19 @@ func TestDroplets(t *testing.T) {
 			},
 		},
 		{
+			Description: "Update droplet metadata",
+			Route: testutil.MockRoute{
+				Method:   "PATCH",
+				Endpoint: "/v3/droplets/59c3d133-2b83-46f3-960e-7765a129aea4",
+				Output:   g.Single(droplet),
+				Status:   http.StatusOK,
+			},
+			Expected: droplet,
+			Action: func(c *Client, t *testing.T) (any, error) {
+				return c.Droplets.UpdateMetadata(context.Background(), "59c3d133-2b83-46f3-960e-7765a129aea4", &resource.DropletMetadataUpdate{})
+			},
+		},
+		{
 			Description: "Copy droplet",
 			Route: testutil.MockRoute{
 				Method:      "POST",

--- a/resource/droplet.go
+++ b/resource/droplet.go
@@ -54,6 +54,10 @@ type DropletUpdate struct {
 	Image    string   `json:"image"`
 }
 
+type DropletMetadataUpdate struct {
+	Metadata Metadata `json:"metadata,omitempty"`
+}
+
 type DropletCurrent struct {
 	Data  Relationship    `json:"data"`
 	Links map[string]Link `json:"links"`


### PR DESCRIPTION
- before, the droplet update feature will update the "image" field too, which does not always work: https://github.com/cloudfoundry/go-cfclient/issues/455
- hence, provide a way for the droplet metadata to be updated independently from the "image" field