### PR TITLE
Add ability to only update droplet metadata

### DIFF
--- a/client/droplet_test.go
+++ b/client/droplet_test.go
@@ -177,16 +177,37 @@ func TestDroplets(t *testing.T) {
 			},
 		},
 		{
-			Description: "Update droplet",
+			Description: "Update droplet image",
 			Route: testutil.MockRoute{
 				Method:   "PATCH",
 				Endpoint: "/v3/droplets/59c3d133-2b83-46f3-960e-7765a129aea4",
 				Output:   g.Single(droplet),
 				Status:   http.StatusOK,
+				PostForm: `{ "image": "image-identifier"}`,
 			},
 			Expected: droplet,
 			Action: func(c *Client, t *testing.T) (any, error) {
-				return c.Droplets.Update(context.Background(), "59c3d133-2b83-46f3-960e-7765a129aea4", &resource.DropletUpdate{})
+				return c.Droplets.Update(context.Background(), "59c3d133-2b83-46f3-960e-7765a129aea4", &resource.DropletUpdate{
+					Image: testutil.StringPtr("image-identifier"),
+				})
+			},
+		},
+		{
+			Description: "Update droplet metadata",
+			Route: testutil.MockRoute{
+				Method:   "PATCH",
+				Endpoint: "/v3/droplets/59c3d133-2b83-46f3-960e-7765a129aea4",
+				Output:   g.Single(droplet),
+				Status:   http.StatusOK,
+				PostForm: `{ "metadata": { "labels": { "key": "value" }, "annotations": {"note": "detailed information"}}}`,
+			},
+			Expected: droplet,
+			Action: func(c *Client, t *testing.T) (any, error) {
+				return c.Droplets.Update(context.Background(), "59c3d133-2b83-46f3-960e-7765a129aea4", &resource.DropletUpdate{
+					Metadata: resource.NewMetadata().
+						WithLabel("", "key", "value").
+						WithAnnotation("", "note", "detailed information"),
+				})
 			},
 		},
 		{

--- a/resource/droplet.go
+++ b/resource/droplet.go
@@ -50,8 +50,8 @@ type DropletList struct {
 }
 
 type DropletUpdate struct {
-	Metadata Metadata `json:"metadata,omitempty"`
-	Image    string   `json:"image"`
+	Metadata *Metadata `json:"metadata,omitempty"`
+	Image    *string   `json:"image,omitempty"`
 }
 
 type DropletCurrent struct {


### PR DESCRIPTION
Fixed the droplet update resource definition to match all other usages of metadata to use a pointer type and omitempty.