### PR TITLE
Build update image

### DIFF
--- a/client/build_test.go
+++ b/client/build_test.go
@@ -57,7 +57,7 @@ func TestBuilds(t *testing.T) {
 			},
 		},
 		{
-			Description: "Update build",
+			Description: "Update build metadata",
 			Route: testutil.MockRoute{
 				Method:   "PATCH",
 				Endpoint: "/v3/builds/be9db090-ad79-41c1-9a01-6200d896f20f",
@@ -71,6 +71,27 @@ func TestBuilds(t *testing.T) {
 				r.Metadata = resource.NewMetadata().
 					WithAnnotation("", "foo", "bar").
 					WithLabel("", "env", "dev")
+				return c.Builds.Update(context.Background(), "be9db090-ad79-41c1-9a01-6200d896f20f", r)
+			},
+		},
+		{
+			Description: "Update build image",
+			Route: testutil.MockRoute{
+				Method:   "PATCH",
+				Endpoint: "/v3/builds/be9db090-ad79-41c1-9a01-6200d896f20f",
+				Output:   g.Single(build),
+				PostForm: `{"state": "STAGED", "lifecycle": {"data": {"image": "image-identifier"}}}`,
+				Status:   http.StatusOK,
+			},
+			Expected: build,
+			Action: func(c *Client, t *testing.T) (any, error) {
+				r := resource.NewBuildUpdate()
+				r.State = "STAGED"
+				r.Lifecycle = &resource.Lifecycle{
+					BuildpackData: resource.BuildpackLifecycle{
+						Image: "image-identifier",
+					},
+				}
 				return c.Builds.Update(context.Background(), "be9db090-ad79-41c1-9a01-6200d896f20f", r)
 			},
 		},

--- a/client/droplet_test.go
+++ b/client/droplet_test.go
@@ -188,7 +188,7 @@ func TestDroplets(t *testing.T) {
 			Expected: droplet,
 			Action: func(c *Client, t *testing.T) (any, error) {
 				return c.Droplets.Update(context.Background(), "59c3d133-2b83-46f3-960e-7765a129aea4", &resource.DropletUpdate{
-					Image: testutil.StringPtr("image-identifier"),
+					Image: "image-identifier",
 				})
 			},
 		},

--- a/resource/app.go
+++ b/resource/app.go
@@ -70,6 +70,7 @@ type Lifecycle struct {
 type BuildpackLifecycle struct {
 	Buildpacks []string `json:"buildpacks,omitempty"`
 	Stack      string   `json:"stack,omitempty"`
+	Image      string   `json:"image,omitempty"`
 }
 
 type AppWithIncluded struct {

--- a/resource/build.go
+++ b/resource/build.go
@@ -40,7 +40,9 @@ type BuildCreate struct {
 }
 
 type BuildUpdate struct {
-	Metadata *Metadata `json:"metadata,omitempty"`
+	Metadata  *Metadata  `json:"metadata,omitempty"`
+	Lifecycle *Lifecycle `json:"lifecycle,omitempty"`
+	State     string     `json:"state,omitempty"`
 }
 
 type BuildList struct {

--- a/resource/droplet.go
+++ b/resource/droplet.go
@@ -51,7 +51,7 @@ type DropletList struct {
 
 type DropletUpdate struct {
 	Metadata *Metadata `json:"metadata,omitempty"`
-	Image    *string   `json:"image,omitempty"`
+	Image    string    `json:"image,omitempty"`
 }
 
 type DropletCurrent struct {


### PR DESCRIPTION
Add optional image update to builds for consistency with droplets and remove unnecessary pointer from droplet image field.