### PR TITLE
feat: Support assertion based auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,19 @@ Client and client secret:
 cfg, _ := config.New("https://api.example.org", config.ClientCredentials("cf", "secret"))
 cf, _ := client.New(cfg)
 ```
+Client and client assertion:
+```go
+cfg, _ := config.New("https://api.example.org", config.ClientCredentials("cf",""),config.ClientAssertion("client-assertion-token"))
+cf, _ := client.New(cfg)
+```
 Static OAuth token, which requires both an access and refresh token:
 ```go
 cfg, _ := config.New("https://api.example.org", config.Token(accessToken, refreshToken))
+cf, _ := client.New(cfg)
+```
+Using JWT Bearer Assertion Grant
+```go
+cfg, _ := config.New("https://api.example.org",config.JWTBearerAssertion("jwt-assertion-token"))
 cf, _ := client.New(cfg)
 ```
 For more detailed examples of using the various authentication and configuration options, see the

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,6 +12,8 @@ import (
 
 const accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6InRlc3QgY2YgdG9rZW4iLCJpYXQiOjE1MTYyMzkwMjIsImV4cCI6MTUxNjIzOTAyMn0.mLvUvu-ED_lIkyI3UTXS_hUEPPFdI0BdNqRMgMThAhk"
 const refreshToken = "secret-refresh-token"
+const clientAssertion = "client-assertion-token"
+const jwtAssertion = "jwt-assertion-token"
 
 func TestInvalidConfig(t *testing.T) {
 	c := &Config{}
@@ -110,6 +112,17 @@ func TestClientCredentials(t *testing.T) {
 		require.NotNil(t, c.oAuthToken)
 		require.Equal(t, accessToken, c.oAuthToken.AccessToken)
 		require.Equal(t, refreshToken, c.oAuthToken.RefreshToken)
+		require.Equal(t, GrantTypeClientCredentials, c.grantType)
+	})
+
+	t.Run("with clientID and client assertion", func(t *testing.T) {
+		c, err := New("https://api.example.com",
+			ClientCredentials("clientID", ""),
+			ClientAssertion(clientAssertion),
+			AuthTokenURL("https://login.cf.example.com", "https://token.cf.example.com")) // skip service discovery
+		require.NoError(t, err)
+		require.Equal(t, "clientID", c.clientID)
+		require.Equal(t, clientAssertion, c.clientAssertion)
 		require.Equal(t, GrantTypeClientCredentials, c.grantType)
 	})
 }
@@ -222,5 +235,16 @@ func TestNewConfigFromCFHomeDir(t *testing.T) {
 		require.Equal(t, "pass", cfg.password)
 		require.Equal(t, DefaultClientID, cfg.clientID)
 		require.Equal(t, GrantTypePassword, cfg.grantType)
+	})
+}
+
+func TestJwBearerAssertion(t *testing.T) {
+	t.Run("minimalistic setup", func(t *testing.T) {
+		cfg, err := New("https://api.example.com",
+			JWTBearerAssertion(jwtAssertion),
+			AuthTokenURL("https://login.cf.example.com", "https://token.cf.example.com")) // skip service discovery
+		require.NoError(t, err)
+		require.Equal(t, jwtAssertion, cfg.assertion)
+		require.Equal(t, GrantTypeJwtBearer, cfg.grantType)
 	})
 }

--- a/config/options.go
+++ b/config/options.go
@@ -31,6 +31,24 @@ func ClientCredentials(clientID, clientSecret string) Option {
 	}
 }
 
+// ClientAssertion is a functional option to set client assertion.
+func ClientAssertion(assertion string) Option {
+	return func(c *Config) error {
+		// if set, must be a valid JWT token
+		// alternative to client secret
+		// usually used with ClientCredentials
+		// can be combined with JWTBearerAssertion
+		// refer RFC 7523 for more details
+		if assertion = strings.TrimSpace(assertion); assertion == "" {
+			return errors.New("assertion must be valid JWT Token")
+		} else {
+			c.clientAssertion = assertion
+		}
+
+		return nil
+	}
+}
+
 // UserPassword is a functional option to set user credentials.
 func UserPassword(username, password string) Option {
 	return func(c *Config) error {
@@ -41,6 +59,24 @@ func UserPassword(username, password string) Option {
 		}
 		c.username = username
 		c.password = password
+		return nil
+	}
+}
+
+// JWTBearerAssertion is a functional option to set JWT Bearer credentials.
+func JWTBearerAssertion(assertion string) Option {
+	return func(c *Config) error {
+		// if set, must be a valid JWT token
+		// can be used alone
+		// or with ClientCredentials
+		// or with ClientCredentials + ClientAssertion
+		// refer RFC 7523 for more details
+		if assertion = strings.TrimSpace(assertion); assertion == "" {
+			return errors.New("assertion is required for JWT Bearer grant type")
+		} else {
+			c.assertion = assertion
+		}
+
 		return nil
 	}
 }

--- a/examples/auth/main.go
+++ b/examples/auth/main.go
@@ -20,6 +20,9 @@ const clientID = "cf"
 const clientSecret = "secret"
 const accessToken = "<access-token>"
 const refreshToken = "<refresh-token>"
+const jwtAssertion = "<jwt-assertion>"
+const clientAssertion = "<client-assertion>"
+const origin = "<origin>"
 
 func main() {
 	err := execute()
@@ -69,6 +72,32 @@ func execute() error {
 	cfg, err = config.New(apiURL,
 		config.Token(accessToken, refreshToken),
 		config.SkipTLSValidation())
+	if err != nil {
+		return err
+	}
+	err = listOrganizationsWithConfig(cfg)
+	if err != nil {
+		return err
+	}
+
+	// use the hardcoded CF API endpoint and JWT Bearer Assertion token and optional origin
+	// minimally requires the assertion
+	cfg, err = config.New(apiURL,
+		config.JWTBearerAssertion(jwtAssertion),
+		config.Origin(origin))
+	if err != nil {
+		return err
+	}
+	err = listOrganizationsWithConfig(cfg)
+	if err != nil {
+		return err
+	}
+
+	// use the hardcoded CF API endpoint and JWT Bearer Assertion token and optional origin
+	// minimally requires the assertion
+	cfg, err = config.New(apiURL,
+		config.ClientCredentials(clientID, ""),
+		config.ClientAssertion(clientAssertion))
 	if err != nil {
 		return err
 	}

--- a/internal/jwt/token.go
+++ b/internal/jwt/token.go
@@ -5,14 +5,34 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
 	"golang.org/x/oauth2"
 )
 
+const (
+	grantTypeJwtBearer  = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+	clientAssertionType = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+)
+
 type tokenPayload struct {
 	Expiration int64 `json:"exp"`
+}
+
+type JWTAssertionTokenSource struct { // revive:disable-line:exported
+	Assertion       string
+	ClientAssertion string
+	ClientID        string
+	ClientSecret    string
+	GrantType       string
+	Scopes          []string
+	TokenURL        string
+	HTTPClient      *http.Client
 }
 
 func AccessTokenExpiration(accessToken string) (time.Time, error) {
@@ -63,4 +83,108 @@ func ToOAuth2Token(accessToken, refreshToken string) (*oauth2.Token, error) {
 		oAuthToken.Expiry = exp
 	}
 	return oAuthToken, nil
+}
+
+func (s *JWTAssertionTokenSource) Token() (*oauth2.Token, error) {
+	data := url.Values{}
+
+	if s.TokenURL == "" {
+		return nil, fmt.Errorf("token URL is required")
+	}
+	if s.GrantType == "" {
+		data.Set("grant_type", grantTypeJwtBearer)
+	} else {
+		data.Set("grant_type", s.GrantType)
+	}
+	// Assertion is required for JWT Bearer grant type
+	if s.Assertion == "" && (s.GrantType == grantTypeJwtBearer || s.GrantType == "") {
+		return nil, fmt.Errorf("assertion is required for JWT Bearer grant type")
+	}
+
+	if s.Assertion != "" {
+		if err := validateJWTTokenFormat(s.Assertion); err != nil {
+			return nil, err
+		}
+		data.Set("assertion", s.Assertion)
+	}
+
+	// Optional client_id
+	if s.ClientID != "" {
+		data.Set("client_id", s.ClientID)
+	}
+
+	// Optional client_secret
+	if s.ClientSecret != "" {
+		if s.ClientID == "" {
+			return nil, fmt.Errorf("client_id is required when using client secret")
+		}
+		data.Set("client_secret", s.ClientSecret)
+	}
+
+	// Optional client_assertion
+	if s.ClientAssertion != "" {
+		if s.ClientID == "" {
+			return nil, fmt.Errorf("client_id is required when using client assertion")
+		}
+		if err := validateJWTTokenFormat(s.ClientAssertion); err != nil {
+			return nil, err
+		}
+		data.Set("client_assertion_type", clientAssertionType)
+		data.Set("client_assertion", s.ClientAssertion)
+	}
+	if len(s.Scopes) > 0 {
+		data.Set("scope", strings.Join(s.Scopes, " "))
+	}
+
+	req, err := http.NewRequest("POST", s.TokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("token request object creation failed: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := s.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("token request failed: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("failed to close response body: %v", err)
+		}
+	}()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("token request failed: %s", body)
+	}
+
+	var token oauth2.Token
+	err = json.Unmarshal(body, &token)
+	if err != nil {
+		return nil, fmt.Errorf("token unmarshal error: %w", err)
+	}
+	return &token, nil
+}
+
+// validateJWTTokenFormat checks if the provided JWT token has a valid format.
+func validateJWTTokenFormat(token string) error {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return errors.New("token must have three parts separated by '.'")
+	}
+
+	for i, part := range parts {
+		if part == "" {
+			return fmt.Errorf("token part is empty")
+		}
+		if _, err := base64.RawURLEncoding.DecodeString(part); err != nil {
+			return fmt.Errorf("invalid base64 encoding in part %d", i+1)
+		}
+	}
+
+	return nil
 }

--- a/internal/jwt/token_test.go
+++ b/internal/jwt/token_test.go
@@ -1,13 +1,31 @@
 package jwt
 
 import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
-const accessToken = `bearer ignored.eyJqdGkiOiJhOGE5YTJjNDY5MzY0YzU3YmI2M2QxMWFiYzdhNjgzOSIsInN1YiI6IjJiNmMzM2ZlLTExZTItNGQwMi05OTNhLTdiNjQ5ZjhhMmI5YyIsInNjb3BlIjpbIm9wZW5pZCIsInJvdXRpbmcucm91dGVyX2dyb3Vwcy53cml0ZSIsIm5ldHdvcmsud3JpdGUiLCJzY2ltLnJlYWQiLCJjbG91ZF9jb250cm9sbGVyLmFkbWluIiwidWFhLnVzZXIiLCJyb3V0aW5nLnJvdXRlcl9ncm91cHMucmVhZCIsImNsb3VkX2NvbnRyb2xsZXIucmVhZCIsInBhc3N3b3JkLndyaXRlIiwiY2xvdWRfY29udHJvbGxlci53cml0ZSIsIm5ldHdvcmsuYWRtaW4iLCJkb3BwbGVyLmZpcmVob3NlIiwic2NpbS53cml0ZSJdLCJjbGllbnRfaWQiOiJjZiIsImNpZCI6ImNmIiwiYXpwIjoiY2YiLCJncmFudF90eXBlIjoicGFzc3dvcmQiLCJ1c2VyX2lkIjoiMmI2YzMzZmUtMTFlMi00ZDAyLTk5M2EtN2I2NDlmOGEyYjljIiwib3JpZ2luIjoidWFhIiwidXNlcl9uYW1lIjoiYWRtaW4iLCJlbWFpbCI6ImFkbWluIiwiYXV0aF90aW1lIjoxNjk4MDk2Mzc2LCJyZXZfc2lnIjoiZmNlMmY2MDAiLCJpYXQiOjE2OTgwOTY0MDgsImV4cCI6MTY5ODA5NjQ2OCwiaXNzIjoiaHR0cHM6Ly91YWEuc3lzLmgyby0yLTE5MTQ5Lmgyby52bXdhcmUuY29tL29hdXRoL3Rva2VuIiwiemlkIjoidWFhIiwiYXVkIjpbImRvcHBsZXIiLCJyb3V0aW5nLnJvdXRlcl9ncm91cHMiLCJvcGVuaWQiLCJjbG91ZF9jb250cm9sbGVyIiwicGFzc3dvcmQiLCJzY2ltIiwidWFhIiwibmV0d29yayIsImNmIl19.ignored`
+const (
+	validToken = "a.test.token"
+
+	validAssertionToken = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.KMUFsIDTnFmyG3nMiGM6H9FNFUROf3wh7SmqJp-QV30`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            // revive:disable:line-length-limit
+	accessToken         = `bearer ignored.eyJqdGkiOiJhOGE5YTJjNDY5MzY0YzU3YmI2M2QxMWFiYzdhNjgzOSIsInN1YiI6IjJiNmMzM2ZlLTExZTItNGQwMi05OTNhLTdiNjQ5ZjhhMmI5YyIsInNjb3BlIjpbIm9wZW5pZCIsInJvdXRpbmcucm91dGVyX2dyb3Vwcy53cml0ZSIsIm5ldHdvcmsud3JpdGUiLCJzY2ltLnJlYWQiLCJjbG91ZF9jb250cm9sbGVyLmFkbWluIiwidWFhLnVzZXIiLCJyb3V0aW5nLnJvdXRlcl9ncm91cHMucmVhZCIsImNsb3VkX2NvbnRyb2xsZXIucmVhZCIsInBhc3N3b3JkLndyaXRlIiwiY2xvdWRfY29udHJvbGxlci53cml0ZSIsIm5ldHdvcmsuYWRtaW4iLCJkb3BwbGVyLmZpcmVob3NlIiwic2NpbS53cml0ZSJdLCJjbGllbnRfaWQiOiJjZiIsImNpZCI6ImNmIiwiYXpwIjoiY2YiLCJncmFudF90eXBlIjoicGFzc3dvcmQiLCJ1c2VyX2lkIjoiMmI2YzMzZmUtMTFlMi00ZDAyLTk5M2EtN2I2NDlmOGEyYjljIiwib3JpZ2luIjoidWFhIiwidXNlcl9uYW1lIjoiYWRtaW4iLCJlbWFpbCI6ImFkbWluIiwiYXV0aF90aW1lIjoxNjk4MDk2Mzc2LCJyZXZfc2lnIjoiZmNlMmY2MDAiLCJpYXQiOjE2OTgwOTY0MDgsImV4cCI6MTY5ODA5NjQ2OCwiaXNzIjoiaHR0cHM6Ly91YWEuc3lzLmgyby0yLTE5MTQ5Lmgyby52bXdhcmUuY29tL29hdXRoL3Rva2VuIiwiemlkIjoidWFhIiwiYXVkIjpbImRvcHBsZXIiLCJyb3V0aW5nLnJvdXRlcl9ncm91cHMiLCJvcGVuaWQiLCJjbG91ZF9jb250cm9sbGVyIiwicGFzc3dvcmQiLCJzY2ltIiwidWFhIiwibmV0d29yayIsImNmIl19.ignored` // revive:disable:line-length-limit
+)
+
+func mockServer(statusCode int, responseBody string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(statusCode)
+		if _, err := fmt.Fprint(w, responseBody); err != nil {
+			log.Fatalf("failed to write response body: %v", err)
+		}
+	}))
+}
 
 func TestToken(t *testing.T) {
 	t.Run("Test AccessTokenExpiration", func(t *testing.T) {
@@ -34,5 +52,104 @@ func TestToken(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, token)
 		require.Equal(t, "bearer", token.TokenType)
+	})
+
+}
+
+func TestTokenSource(t *testing.T) {
+	t.Run("Test JWTAssertionTokenSource", func(t *testing.T) {
+		ts := mockServer(200, `{"access_token":"`+validToken+`","token_type":"Bearer","expires_in":3600}`)
+		defer ts.Close()
+		src := &JWTAssertionTokenSource{
+			Assertion:       validAssertionToken,
+			ClientAssertion: validAssertionToken,
+			ClientID:        "test-client-id",
+			ClientSecret:    "test-client-secret",
+			GrantType:       grantTypeJwtBearer,
+			TokenURL:        ts.URL,
+			HTTPClient:      http.DefaultClient,
+		}
+
+		token, err := src.Token()
+		require.NoError(t, err)
+		require.NotNil(t, token)
+	})
+	t.Run("Test JWTAssertionTokenSource minimal", func(t *testing.T) {
+		ts := mockServer(200, `{"access_token":"`+validToken+`","token_type":"Bearer","expires_in":3600}`)
+		defer ts.Close()
+		src := &JWTAssertionTokenSource{
+			Assertion: validAssertionToken,
+			TokenURL:  ts.URL,
+		}
+
+		token, err := src.Token()
+		require.NoError(t, err)
+		require.NotNil(t, token)
+	})
+	t.Run("Test JWTAssertionTokenSource invalid asssertion format", func(t *testing.T) {
+		ts := mockServer(200, `{"access_token":"`+validToken+`","token_type":"Bearer","expires_in":3600}`)
+		defer ts.Close()
+		src := &JWTAssertionTokenSource{
+			Assertion: validAssertionToken + `additional.invalid.part`,
+			TokenURL:  ts.URL,
+		}
+
+		_, err := src.Token()
+		require.EqualError(t, err, "token must have three parts separated by '.'")
+
+	})
+	t.Run("Test JWTAssertionTokenSource invalid encoding", func(t *testing.T) {
+		ts := mockServer(200, `{"access_token":"`+validToken+`","token_type":"Bearer","expires_in":3600}`)
+		defer ts.Close()
+		src := &JWTAssertionTokenSource{
+			Assertion: validAssertionToken + ` `,
+			TokenURL:  ts.URL,
+		}
+
+		_, err := src.Token()
+		require.EqualError(t, err, "invalid base64 encoding in part 3")
+
+	})
+	t.Run("Test JWTAssertionTokenSource without assertion and GrantType JWTBearer", func(t *testing.T) {
+		ts := mockServer(200, `{"access_token":"`+validToken+`","token_type":"Bearer","expires_in":3600}`)
+		defer ts.Close()
+		src := &JWTAssertionTokenSource{
+			TokenURL: ts.URL,
+		}
+		_, err := src.Token()
+		require.EqualError(t, err, "assertion is required for JWT Bearer grant type")
+	})
+	t.Run("Test JWTAssertionTokenSource without Token URL", func(t *testing.T) {
+		ts := mockServer(200, `{"access_token":"`+validToken+`","token_type":"Bearer","expires_in":3600}`)
+		defer ts.Close()
+		src := &JWTAssertionTokenSource{
+			Assertion: validAssertionToken + ` `,
+		}
+		_, err := src.Token()
+		require.EqualError(t, err, "token URL is required")
+	})
+	t.Run("Test client_credential with assertion flow", func(t *testing.T) {
+		ts := mockServer(200, `{"access_token":"`+validToken+`","token_type":"Bearer","expires_in":3600}`)
+		defer ts.Close()
+		src := &JWTAssertionTokenSource{
+			ClientAssertion: validAssertionToken,
+			ClientID:        "test-client-id",
+			GrantType:       `client_credentials`,
+			TokenURL:        ts.URL,
+		}
+		token, err := src.Token()
+		require.NoError(t, err)
+		require.NotNil(t, token)
+	})
+	t.Run("Test client_credential assertion without client id", func(t *testing.T) {
+		ts := mockServer(200, `{"access_token":"`+validToken+`","token_type":"Bearer","expires_in":3600}`)
+		defer ts.Close()
+		src := &JWTAssertionTokenSource{
+			ClientAssertion: validAssertionToken,
+			GrantType:       `client_credentials`,
+			TokenURL:        ts.URL,
+		}
+		_, err := src.Token()
+		require.EqualError(t, err, "client_id is required when using client assertion")
 	})
 }


### PR DESCRIPTION
This PR brings in support for authentication:-
- Using JWT Bearer token instead of user/password clientid/client-secret flow
- Using Client Assertion Token instead of client Secret

This is primarly used with the new JWT Bearer
- Based on RFC-7523
- Feature is supported from UAA 76.23.0 & cf-cli v8.12.0

fixes: #474