### PR TITLE
Add support for setting app lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Support for setting and reading application lifecycle (`buildpack`, `docker`, and `cnb`/Cloud Native Buildpacks) in V3 API.
+- Custom marshaling/unmarshaling for `Lifecycle` struct to support multiple lifecycle types.
+- Unit tests for all lifecycle types, including CNB.
+
+### Changed
+
+- All lifecycle-related test expectations updated to match new marshaling output (both `type` and `data` fields).
+
+### Notes
+
+- For CNB, only `buildpacks` and `stack` fields are currently supported. Additional fields may be added in the future as the API evolves.
+- No breaking changes for existing users of buildpack or docker lifecycles.

--- a/client/build_test.go
+++ b/client/build_test.go
@@ -80,7 +80,7 @@ func TestBuilds(t *testing.T) {
 				Method:   "PATCH",
 				Endpoint: "/v3/builds/be9db090-ad79-41c1-9a01-6200d896f20f",
 				Output:   g.Single(build),
-				PostForm: `{"state": "STAGED", "lifecycle": {"data": {"image": "image-identifier"}}}`,
+				PostForm: `{"state": "STAGED", "lifecycle": {"type": "docker", "data": {"image": "image-identifier"}}}`,
 				Status:   http.StatusOK,
 			},
 			Expected: build,
@@ -88,7 +88,8 @@ func TestBuilds(t *testing.T) {
 				r := resource.NewBuildUpdate()
 				r.State = "STAGED"
 				r.Lifecycle = &resource.Lifecycle{
-					BuildpackData: resource.BuildpackLifecycle{
+					Type: "docker",
+					Data: &resource.DockerLifecycle{
 						Image: "image-identifier",
 					},
 				}

--- a/operation/push.go
+++ b/operation/push.go
@@ -355,7 +355,7 @@ func (p *AppPushOperation) buildDroplet(ctx context.Context, pkg *resource.Packa
 	} else {
 		newBuild.Lifecycle = &resource.Lifecycle{
 			Type: resource.LifecycleBuildpack.String(),
-			BuildpackData: resource.BuildpackLifecycle{
+			Data: &resource.BuildpackLifecycle{
 				Buildpacks: manifest.Buildpacks,
 				Stack:      manifest.Stack,
 			},

--- a/resource/app.go
+++ b/resource/app.go
@@ -62,6 +62,10 @@ type EnvVarResponse struct {
 	Links map[string]Link `json:"links"`
 }
 
+// Lifecycle represents the Cloud Foundry V3 application lifecycle block.
+// It supports buildpack, docker, and cnb (Cloud Native Buildpacks) types.
+// Custom marshaling/unmarshaling is used to ensure correct JSON structure for each type.
+// To add support for new lifecycle types, extend the marshaler/unmarshaler logic below.
 type Lifecycle struct {
 	Type string      `json:"type,omitempty"`
 	Data interface{} `json:"data,omitempty"`


### PR DESCRIPTION
I want to add support for using the CNB lifecycle when pushing apps using the Terraform provider, which uses this CF client library. I thought it would be best to first have CNB lifecycle support exist here in the client that the Terraform provider uses.

Confession time 🥺👉👈 : I am not a good Go programmer, but GitHub Copilot claims to be. I don't personally see any problems with the code it generated, but not being an expert in Go code, tooling, and testing facilities, it's possible and even likely that I missed something. Please let me know if you see problems or want changes!